### PR TITLE
Fix path of require matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ValidatesCPF 
+# ValidatesCPF
 
 [![Gem Version](https://badge.fury.io/rb/validates_cpf.png)](http://badge.fury.io/rb/validates_cpf) [![Build Status](https://secure.travis-ci.org/plribeiro3000/validates_cpf.png?branch=master)](http://travis-ci.org/plribeiro3000/validates_cpf) [![Dependency Status](https://gemnasium.com/plribeiro3000/validates_cpf.png)](https://gemnasium.com/plribeiro3000/validates_cpf) [![Coverage Status](https://coveralls.io/repos/plribeiro3000/validates_cpf/badge.png?branch=master)](https://coveralls.io/r/plribeiro3000/validates_cpf)  [![Code Climate](https://codeclimate.com/github/plribeiro3000/validates_cpf.png)](https://codeclimate.com/github/plribeiro3000/validates_cpf)
 
@@ -41,7 +41,7 @@ end
 Require the matcher:
 
 ```ruby
-require 'validates_cpf/require_a_valid_matcher'
+require 'validates_cpf/require_a_valid_cpf_matcher'
 ```
 
 Use in your tests:


### PR DESCRIPTION
It changes the path from `require 'validates_cpf/require_a_valid_matcher'` to `require 'validates_cpf/require_a_valid_cpf_matcher'`